### PR TITLE
Use bitmask and shifts with `BitArray` chunks.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,3 +2,6 @@ name = "DiBitVectors"
 uuid = "b332d270-17d7-4a15-8ba9-1b15059bf12d"
 authors = ["Seth Bromberger <github@bromberger.com>"]
 version = "0.1.0"
+
+[deps]
+BitOperations = "e1e0eea2-bc69-5bf6-8574-13634873a17c"

--- a/src/DiBitVectors.jl
+++ b/src/DiBitVectors.jl
@@ -1,4 +1,4 @@
-module DiBitVectortors
+module DiBitVectors
 
 import Base: getindex, setindex!, size, length
 
@@ -22,7 +22,7 @@ struct DiBitVector <: AbstractVector{Bool}
     end
 end
 
-@inline checkbounds(D::DiBitVector, n::Integer) = n * 2 ≤ length(D.data) || throw(BoundsError(D, n))
+@inline checkbounds(D::DiBitVector, n::Integer) =  0 < n * 2 ≤ length(D.data) || throw(BoundsError(D, n))
 
 """
     _set_dibit!(D, n, v)


### PR DESCRIPTION
Instead of reading and writing bits individually, use mask and shifts through `BitOperations.jl` to read/write the entire chunk.  `BitOperations.jl` can be replaced pretty easily, but I wanted to keep it more simple to begin with.

Comparison of performance.

Old Method
```
a=DiBitVector(1024);
@btime map!(i->mod1(i,4)-1,$a,eachindex($a)); #5.667 μs (0 allocations: 0 bytes)
@btime sum(i->$a[i],eachindex($a)); #5.280 μs (1 allocation: 16 bytes)
@btime $a .= 1 # 3.562 μs (0 allocations: 0 bytes)
```

New Method
```
a=DiBitVector(1024);
@btime map!(i->mod1(i,4)-1,$a,eachindex($a)); #2.789 μs (0 allocations: 0 bytes)
@btime sum(i->$a[i],eachindex($a)); #1.460 μs (1 allocation: 16 bytes)
@btime $a .= 1  #1.560 μs (0 allocations: 0 bytes)
```