### PR TITLE
Add DiBitVector3 to benchmark

### DIFF
--- a/src/DiBit3.jl
+++ b/src/DiBit3.jl
@@ -1,0 +1,47 @@
+using BitOperations
+
+struct DiBitVector3 <: AbstractVector{Bool}
+    data::BitVector
+    function DiBitVector3(n::Integer, v::Integer = 0)
+        if v == 0
+            data = falses(n*2)
+        elseif v == 3
+            data = trues(n*2)
+        else
+            data = BitVector(undef, n*2)
+            b1 = v >> 1 != 0
+            b2 = v & 0x01 != 0
+            @inbounds for i = 1:n
+                Base.unsafe_bitsetindex!(data.chunks, b1, 2*i-1)
+                Base.unsafe_bitsetindex!(data.chunks, b2, 2*i)
+            end
+        end
+        return new(data)
+    end
+end
+
+@inline checkbounds(D::DiBitVector, n::Integer) =  0 < n * 2 ≤ length(D.data) || throw(BoundsError(D, n))
+
+@inline function setindex!(D::DiBitVector3, v::Integer, n::Integer)
+    (0 ≤ v ≤ 3) || throw(DomainError(v, "Values must be between 0 and 3."))
+    @boundscheck checkbounds(D, n)
+    chunk,pos = _chunk_pos(n)
+    D.data.chunks[chunk] = bset(D.data.chunks[chunk],pos:pos+1,v)
+end
+
+@inline function getindex(D::DiBitVector3, n::Integer)
+    @boundscheck checkbounds(D, n)
+    chunk,pos = _chunk_pos(n)
+    UInt8( bget(D.data.chunks[chunk],pos:pos+1) )
+end
+
+@inline function _chunk_pos(n)
+    chunk = bget(n-1,5:63)+1 # 1-based chunk index
+    pos = 2bget(n-1,0:4) # 0-based bit position index
+    return (chunk,pos)
+end
+
+@inline length(D::DiBitVector3) = length(D.data) ÷ 2
+@inline size(D::DiBitVector3) = (length(D),)
+
+export DiBitVector3

--- a/src/DiBitVectors.jl
+++ b/src/DiBitVectors.jl
@@ -37,7 +37,7 @@ Sets index v of DiBitVector D to value n.
     Base.unsafe_bitsetindex!(D.data.chunks, b2, o+1)
 end
 
-@inline function setindex!(D::DiBitVector, v::Integer, n::Integer) 
+@inline function setindex!(D::DiBitVector, v::Integer, n::Integer)
     (0 ≤ v ≤ 3) || throw(DomainError(v, "Values must be between 0 and 3."))
     @boundscheck checkbounds(D, n)
     unsafe_set_dibit!(D, n, v)
@@ -50,7 +50,7 @@ end
 end
 
 @inline function getindex(D::DiBitVector, n::Integer)
-    @boundscheck checkbounds(D, n) 
+    @boundscheck checkbounds(D, n)
     unsafe_get_dibit(D, n)
 end
 
@@ -58,6 +58,7 @@ end
 @inline size(D::DiBitVector) = (length(D),)
 
 include("DiBit2.jl")
+include("DiBit3.jl")
 include("benchmarks.jl")
 export DiBitVector
 export DiBitVector2

--- a/src/DiBitVectors.jl
+++ b/src/DiBitVectors.jl
@@ -1,4 +1,4 @@
-module DiBitVectortors
+module DiBitVectors
 
 import Base: getindex, setindex!, size, length
 
@@ -22,7 +22,7 @@ struct DiBitVector <: AbstractVector{Bool}
     end
 end
 
-@inline checkbounds(D::DiBitVector, n::Integer) = n * 2 ≤ length(D.data) || throw(BoundsError(D, n))
+@inline checkbounds(D::DiBitVector, n::Integer) =  0 < n * 2 ≤ length(D.data) || throw(BoundsError(D, n))
 
 """
     _set_dibit!(D, n, v)

--- a/src/benchmarks.jl
+++ b/src/benchmarks.jl
@@ -1,6 +1,7 @@
 # n = 100_000_000
 # b = DiBitVectors.DiBitVector(n);
 # b2 = DiBitVectors.DiBitVector2(n, 0)
+# b3 = DiBitVectors.DiBitVector3(n,0)
 # data = DiBitVectors.make_data(n)
 #
 using Random
@@ -17,7 +18,7 @@ end
      end
      n
  end
- 
+
  function make_data(n)
      inds = Random.shuffle(1:n)
      vals = rand(0:3, n)


### PR DESCRIPTION
Add a `DiBitVector3` to benchmark performance.  Very similar to `DiBitVecto2` except it utilizes `BitOperations.jl`.